### PR TITLE
Link Sitecore CMS profiling to Sitecore Commerce discounting 

### DIFF
--- a/CS/CSF/App_Config/Include/Reference.Storefront/Reference.Storefront.config
+++ b/CS/CSF/App_Config/Include/Reference.Storefront/Reference.Storefront.config
@@ -98,6 +98,9 @@
           <patch:delete/>
         </processor>
       </commerce.prices.getProductBulkPrices>
+      <renderLayout>
+        <processor type="Sitecore.Reference.Storefront.SitecorePipelines.TrackUserPatternCardMatchingProcessor, Sitecore.Reference.Storefront.Common" patch:after="processor[@type='Sitecore.Analytics.Pipelines.HttpRequest.StartAnalytics, Sitecore.Analytics']"/>
+      </renderLayout>
     </pipelines>
 
     <linkManager defaultProvider="sitecore">

--- a/CS/CSF/Commerce.Storefront.csproj
+++ b/CS/CSF/Commerce.Storefront.csproj
@@ -270,7 +270,9 @@
     <None Include="Sitecore\Copyrights\WebActivatorEx_MSPL.txt" />
     <Content Include="App_Config\Include\Reference.Storefront\Reference.Storefront.Carts.config" />
     <Content Include="App_Config\Include\Reference.Storefront\Reference.Storefront.Catalog.config" />
-    <Content Include="App_Config\Include\Reference.Storefront\Reference.Storefront.config" />
+    <Content Include="App_Config\Include\Reference.Storefront\Reference.Storefront.config">
+      <SubType>Designer</SubType>
+    </Content>
     <Content Include="App_Config\Include\Reference.Storefront\Reference.Storefront.Customer.config" />
     <Content Include="App_Config\Include\Reference.Storefront\Reference.Storefront.Index.Lucene.config" />
     <Content Include="App_Config\Include\Reference.Storefront\Reference.Storefront.Index.Solr.config.example" />
@@ -425,16 +427,7 @@
     <VisualStudio>
       <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
         <WebProjectProperties>
-          <UseIIS>False</UseIIS>
-          <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>38262</DevelopmentServerPort>
-          <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>http://localhost:59296/</IISUrl>
-          <NTLMAuthentication>False</NTLMAuthentication>
-          <UseCustomServer>False</UseCustomServer>
-          <CustomServerUrl>
-          </CustomServerUrl>
-          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+          <SaveServerSettingsInUserFile>True</SaveServerSettingsInUserFile>
         </WebProjectProperties>
       </FlavorProperties>
     </VisualStudio>

--- a/CS/CSF/Managers/AccountManager.cs
+++ b/CS/CSF/Managers/AccountManager.cs
@@ -121,6 +121,8 @@ namespace Sitecore.Reference.Storefront.Managers
                 visitorContext.SetCommerceUser(this.ResolveCommerceUser().Result);
 
                 this.CartManager.MergeCarts(storefront, visitorContext, anonymousVisitorId);
+
+                ResetMatchedPatterCardsField();
             }
 
             return isLoggedIn;
@@ -633,6 +635,15 @@ namespace Sitecore.Reference.Storefront.Managers
 
                 default:
                     return StorefrontManager.GetSystemMessage("UnknownMembershipProviderError");
+            }
+        }
+
+        private static void ResetMatchedPatterCardsField()
+        {
+            if (Context.User.Profile.GetPropertyValue("matched_pattern_cards") != null)
+            {
+                Context.User.Profile.SetPropertyValue("matched_pattern_cards", string.Empty);
+                Context.User.Profile.Save();
             }
         }
 

--- a/CS/Database/Profiles/AdjustSchema.sql
+++ b/CS/Database/Profiles/AdjustSchema.sql
@@ -64,6 +64,12 @@ BEGIN
 END
 GO
 
+IF NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'userobject' AND COLUMN_NAME = 'u_matched_pattern_cards')
+BEGIN
+	ALTER TABLE dbo.UserObject ADD u_matched_pattern_cards nvarchar(256) NULL
+END
+GO
+
 /********************
 	ADD INDEXES
 ********************/

--- a/CS/Database/Profiles/Schema.xml
+++ b/CS/Database/Profiles/Schema.xml
@@ -506,6 +506,13 @@
 					<Attribute name="IsRestricted" displayName="Is Property Restricted" description="Indicates that this property requires an elevated priviledge level in order to perform an update." value="0"/>
 					<Attribute name="IsMappedToLdapUserAccountControl" displayName="Is Mapped To LDAP User Account Control" description="Indicates that this property maps to the userAccountControl DataMember of a LDAP DataSource." value="0"/>
 				</Property>
+        <Property name="matched_pattern_cards" displayName="Matched Pattern Cards" description="A field to store matched pattern cards" propType="STRING">
+          <DataRef idref="UPM_SQLSource.UserObject.u_matched_pattern_cards"/>
+          <Attribute name="MinLength" displayName="Minimum Length" description="Minimum length of this property value" value="0"/>
+          <Attribute name="MaxLength" displayName="Maximum Length" description="Maximum length of this property value" value="256"/>
+          <Attribute name="IsRestricted" displayName="Is Property Restricted" description="Indicates that this property requires an elevated priviledge level in order to perform an update." value="0"/>
+          <Attribute name="IsMappedToLdapUserAccountControl" displayName="Is Mapped To LDAP User Account Control" description="Indicates that this property maps to the userAccountControl DataMember of a LDAP DataSource." value="0"/>
+        </Property>
       </Group>
       <Group name="AccountInfo" displayName="Account Info" description="Accounting Information Group">
         <Property name="org_id" displayName="Organization ID" description="ID of the organization this user is associated with" propType="PROFILE" referenceString="Profile Definitions.Organization">
@@ -714,6 +721,7 @@
 				<DataMember name="u_external_id" displayName="u_external_id" description="External ID for this user" memberType="STRING" isIndexed="1" isRequired="1"/>
 				<DataMember name="u_comment" displayName="Comment" description="Comment for this user" memberType="STRING"/>
 				<DataMember name="u_user_preference" displayName="User Preference" description="Custom user preferences" memberType="STRING"/>
+        <DataMember name="u_matched_pattern_cards" displayName="Matched Pattern Cards" description="Matched Pattern Cards" memberType="STRING"/>
       </DataObject>
       <DataObject name="CreditCards" displayName="Credit Cards">
         <DataMember name="u_payment_group_id" displayName="Payment Group ID" description="ID of an orders system payment group." memberType="STRING" isRequired="1"/>

--- a/Commerce.Server.Storefront.sln
+++ b/Commerce.Server.Storefront.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommonSettings", "Common\CommonSettings\CommonSettings.csproj", "{7B5BFDC5-7552-4EF0-807B-D9B60A78B3FD}"
 EndProject
@@ -25,6 +25,7 @@ Global
 		{8450F330-0271-4091-8809-C671CCD50671}.Release|Any CPU.Build.0 = Release|Any CPU
 		{304F09AD-2FC3-453F-B016-50A1F842E3A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{304F09AD-2FC3-453F-B016-50A1F842E3A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{304F09AD-2FC3-453F-B016-50A1F842E3A9}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
 		{304F09AD-2FC3-453F-B016-50A1F842E3A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{304F09AD-2FC3-453F-B016-50A1F842E3A9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/Common/Project/Common.csproj
+++ b/Common/Project/Common.csproj
@@ -255,6 +255,7 @@
     <Compile Include="Services\VisitedProductDetailsPageResult.cs" />
     <Compile Include="SitecorePipelines\CatalogLinkProvider.cs" />
     <Compile Include="SitecorePipelines\OrderOutcome.cs" />
+    <Compile Include="SitecorePipelines\TrackUserPatternCardMatchingProcessor.cs" />
     <Compile Include="SitecorePipelines\ProductItemResolver.cs" />
     <Compile Include="SitecorePipelines\RegisterDataModelExtensionsBase.cs" />
     <Compile Include="SitecorePipelines\SecuredPageProcessor.cs" />

--- a/Common/Project/SitecorePipelines/TrackUserPatternCardMatchingProcessor.cs
+++ b/Common/Project/SitecorePipelines/TrackUserPatternCardMatchingProcessor.cs
@@ -1,0 +1,98 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ProductItemResolver.cs" company="Sitecore Corporation">
+//     Copyright (c) Sitecore Corporation 1999-2015
+// </copyright>
+// <summary>The product item resolver</summary>
+//---------------------------------------------------------------------
+// Copyright 2015 Sitecore Corporation A/S
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file 
+// except in compliance with the License. You may obtain a copy of the License at
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the 
+// License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+// either express or implied. See the License for the specific language governing permissions 
+// and limitations under the License.
+// -------------------------------------------------------------------------------------------
+
+namespace Sitecore.Reference.Storefront.SitecorePipelines
+{
+    using System.Web;
+    using System.Web.Routing;
+    using Sitecore.Data;
+    using Sitecore.Pipelines;
+    using Sitecore.Web;
+    using Sitecore.Reference.Storefront.Models;
+    using Sitecore.Commerce.Connect.CommerceServer;
+    using Sitecore.Commerce.Connect.CommerceServer.Caching;
+    using Sitecore.Reference.Storefront.Managers;
+    using System.Collections.Generic;
+    using Analytics;
+    using System.Linq;
+
+    /// <summary>
+    /// Class representing a ProductItemResolver
+    /// </summary>
+    public class TrackUserPatternCardMatchingProcessor
+    {
+        /// <summary>
+        /// Runs the processor.
+        /// </summary>
+        /// <param name="args">The args.</param>
+        public virtual void Process(PipelineArgs args)
+        {
+            if (Context.Item != null)
+            {
+                return;
+            }
+
+            if (Context.User.IsAuthenticated && Tracker.Current != null)
+            {
+                string existingList = GetExistingMatchedPatternCards();
+                string newList = GetNewMatchedPatternCard(existingList);
+                SaveMatchedPatternCard(existingList, newList);
+            }
+        }
+
+        private static string GetExistingMatchedPatternCards()
+        {
+            string existingMatchedPatternCardList = string.Empty;
+            if (Context.User.Profile.GetPropertyValue("matched_pattern_cards") != null)
+            {
+                existingMatchedPatternCardList = Context.User.Profile.GetPropertyValue("matched_pattern_cards").ToString();
+            }
+
+            return existingMatchedPatternCardList;
+        }
+
+        private static string GetNewMatchedPatternCard(string existingMatchedPatternCardList)
+        {
+            string newMatchedPatternCardList = string.Empty;
+            foreach (var profileName in Tracker.Current.Interaction.Profiles.GetProfileNames())
+            {
+                var userPattern = Tracker.Current.Interaction.Profiles[profileName];
+                if (userPattern != null && userPattern.Count > 0)
+                {
+                    var newMatchedPatternCard = "[" + userPattern.ProfileName + "." + userPattern.PatternLabel + "]";
+
+                    if (!existingMatchedPatternCardList.Contains(newMatchedPatternCard)
+                        && !newMatchedPatternCardList.Contains(newMatchedPatternCard))
+                    {
+                        newMatchedPatternCardList += newMatchedPatternCard;
+                    }
+                }
+            }
+
+            return newMatchedPatternCardList;
+        }
+
+        private static void SaveMatchedPatternCard(string existingMatchedPatternCardList, string newMatchedPatternCardList)
+        {
+            if (!string.IsNullOrEmpty(newMatchedPatternCardList))
+            {
+                Context.User.Profile.SetPropertyValue("matched_pattern_cards", existingMatchedPatternCardList + newMatchedPatternCardList);
+                Context.User.Profile.Save();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added the ability to trigger discounts based on user behavior. 

This is a basic but effective example of tracking Profile Card matches to a field on the commerce user_object which in turn enables discount expression to be created.

Some quick comments:
- The solution only works for logged in users as anonymous users do not exist in Sitecore Commerce Server.  
- When the user logs in the field against the user is reset.

My checkin does not include these site changes which need to be made to enable this feature:
- Download the fix to pass Object_User to the basket pipeline. 
- In App_Config\Include\Reference.Storefront\Reference.Storefront.config before </pipelines> add 
  <renderLayout>
  <processor type="Sitecore.Reference.Storefront.SitecorePipelines.TrackUserPatternCardMatchingProcessor, Sitecore.Reference.Storefront.Common" patch:after="processor[@type='Sitecore.Analytics.Pipelines.HttpRequest.StartAnalytics, Sitecore.Analytics']"/>
  </renderLayout>
- In Web.config after <add type="System.String" name="SC_UserData" /> add
  <add type="System.String" name="matched_pattern_cards" customProviderData="cs|GeneralInfo.matched_pattern_cards" />
